### PR TITLE
Publish jar files to GitHub packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,10 @@ jobs:
         uses: advanced-security/maven-dependency-submission-action@v4.1.1
       - name: Build with Maven
         run: mvn -B package --file pom.xml -P coverage
+      - name: Publish package
+        run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate JaCoCo Badge
         uses: cicirello/jacoco-badge-generator@v2
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -57,6 +57,7 @@ jobs:
           VALIDATE_GOOGLE_JAVA_FORMAT: false
           VALIDATE_HTML: false
           VALIDATE_JAVA: false
+          VALIDATE_JAVASCRIPT_PRETTIER: false
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_JSCPD: false
           VALIDATE_NATURAL_LANGUAGE: false

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,14 @@
     <module>fakebank-api</module>
   </modules>
 
+  <distributionManagement>
+    <repository>
+        <id>github</id>
+        <name>GitHub Packages</name>
+        <url>https://maven.pkg.github.com/ianrobrien/fakebank</url>
+    </repository>
+  </distributionManagement>
+
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
This pull request includes changes to the CI/CD workflows and the Maven configuration to enhance the build and deployment process. The most important changes include adding a step to publish the package in the CI workflow, updating validation settings in the PR workflow, and configuring the Maven distribution management.

Changes to CI/CD workflows:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR97-R100): Added a step to publish the package using Maven and configured the environment variable `GITHUB_TOKEN` for authentication.
* [`.github/workflows/pr.yaml`](diffhunk://#diff-1eb4e5fd5611777d4e597ef299a1cb5ba8050c28a2dabbd4fbc56205d69e5ddaR60): Added a configuration to disable JavaScript Prettier validation.

Changes to Maven configuration:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R24-R31): Added `distributionManagement` section to configure deployment to GitHub Packages.