### PR TITLE
Remove mapper from account controller

### DIFF
--- a/fakebank-server/src/main/java/no/obrien/fakebank/controller/AccountController.java
+++ b/fakebank-server/src/main/java/no/obrien/fakebank/controller/AccountController.java
@@ -4,8 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import no.obrien.fakebank.api.AccountsApi;
-import no.obrien.fakebank.mapper.AccountMapper;
-import no.obrien.fakebank.model.Account;
 import no.obrien.fakebank.model.AccountBalance;
 import no.obrien.fakebank.model.AccountDetails;
 import no.obrien.fakebank.service.AccountService;
@@ -22,7 +20,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class AccountController implements AccountsApi {
 
   private final AccountService accountService;
-  private final AccountMapper accountMapper;
 
   /***
    * Returns the balance of an account given by its id
@@ -33,8 +30,7 @@ public class AccountController implements AccountsApi {
   @Override
   public ResponseEntity<AccountBalance> getAccountBalance(Long accountId) {
     log.info("Received getAccountBalance request for account {}", accountId);
-    Account account = accountService.getAccount(accountId);
-    return ResponseEntity.ok(accountMapper.toAccountBalance(account));
+    return ResponseEntity.ok(accountService.getAccountBalance(accountId));
   }
 
   /***
@@ -46,7 +42,6 @@ public class AccountController implements AccountsApi {
   @Override
   public ResponseEntity<AccountDetails> getAccountDetails(Long accountId) {
     log.info("Received getAccountDetails request for account {}", accountId);
-    Account account = accountService.getAccount(accountId);
-    return ResponseEntity.ok(accountMapper.toAccountDetails(account));
+    return ResponseEntity.ok(accountService.getAccountDetails(accountId));
   }
 }

--- a/fakebank-server/src/main/java/no/obrien/fakebank/service/AccountService.java
+++ b/fakebank-server/src/main/java/no/obrien/fakebank/service/AccountService.java
@@ -4,7 +4,10 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.obrien.fakebank.exception.InvalidAccountException;
+import no.obrien.fakebank.mapper.AccountMapper;
 import no.obrien.fakebank.model.Account;
+import no.obrien.fakebank.model.AccountBalance;
+import no.obrien.fakebank.model.AccountDetails;
 import no.obrien.fakebank.repository.AccountRepository;
 import org.springframework.stereotype.Service;
 
@@ -17,6 +20,7 @@ import org.springframework.stereotype.Service;
 public class AccountService {
 
   private final AccountRepository accountRepository;
+  private final AccountMapper accountMapper;
 
   /***
    * Gets an account from the given account id
@@ -29,6 +33,26 @@ public class AccountService {
     return Optional.of(accountRepository.findById(accountId))
         .get()
         .orElseThrow(InvalidAccountException::new);
+  }
+
+  /***
+   * Gets an account details from the given account id
+   * @param accountId the account id of the requested account
+   * @return the requested account details
+   * @throws InvalidAccountException when the account id is invalid
+   */
+  public AccountDetails getAccountDetails(Long accountId) throws InvalidAccountException {
+    return accountMapper.toAccountDetails(this.getAccount(accountId));
+  }
+
+  /***
+   * Gets an account balance from the given account id
+   * @param accountId the account id of the requested account
+   * @return the requested account balance
+   * @throws InvalidAccountException when the account id is invalid
+   */
+  public AccountBalance getAccountBalance(Long accountId) throws InvalidAccountException {
+    return accountMapper.toAccountBalance(this.getAccount(accountId));
   }
 
   /***

--- a/fakebank-server/src/test/java/no/obrien/fakebank/controller/AccountControllerTest.java
+++ b/fakebank-server/src/test/java/no/obrien/fakebank/controller/AccountControllerTest.java
@@ -3,22 +3,21 @@ package no.obrien.fakebank.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import no.obrien.fakebank.exception.InvalidAccountException;
 import no.obrien.fakebank.mapper.AccountMapper;
+import no.obrien.fakebank.mapper.AccountMapperImpl;
 import no.obrien.fakebank.model.Account;
-import no.obrien.fakebank.model.AccountBalance;
-import no.obrien.fakebank.model.AccountDetails;
 import no.obrien.fakebank.model.Owner;
+import no.obrien.fakebank.repository.AccountRepository;
 import no.obrien.fakebank.service.AccountService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -27,10 +26,10 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Tests the account controller
  */
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {AccountMapper.class})
+@ContextConfiguration(classes = {AccountMapperImpl.class})
 class AccountControllerTest {
 
-  @MockBean
+  @Autowired
   private AccountMapper accountMapper;
 
   /***
@@ -38,18 +37,18 @@ class AccountControllerTest {
    */
   @Test
   void getBalance_validAccount_returnsValidData() {
-    var accountService = mock(AccountService.class);
-    var owner = mock(Owner.class);
-    when(owner.getFirstName()).thenReturn("Ian Robert");
-    when(owner.getLastName()).thenReturn("O'Brien");
+    var accountRepository = mock(AccountRepository.class);
+    var accountService = new AccountService(accountRepository, accountMapper);
 
-    when(accountService.getAccount(anyLong()))
-        .thenReturn(
-            Account.builder().id(4444L).balance(0.0).currency("NOK").owner(owner).build());
+    given(accountRepository
+        .findById(anyLong()))
+        .willReturn(Optional.of(Account.builder()
+            .id(4444L)
+            .balance(0.0)
+            .currency("NOK")
+            .owner(new Owner()).build()));
 
-    given(accountMapper.toAccountBalance(any(Account.class)))
-        .willReturn(new AccountBalance().accountId(4444L));
-    var accountController = new AccountController(accountService, accountMapper);
+    var accountController = new AccountController(accountService);
 
     var accountBalance = accountController.getAccountBalance(4444L);
 
@@ -60,38 +59,34 @@ class AccountControllerTest {
 
   /***
    * Verifies that an invalid account id throws an invalid account exception
-   * @throws InvalidAccountException
    */
   @Test
-  void getBalance_invalidAccount_throwsException() throws InvalidAccountException {
-    var accountService = mock(AccountService.class);
+  void getBalance_invalidAccount_throwsException() {
+    var accountRepository = mock(AccountRepository.class);
+    given(accountRepository.findById(anyLong())).willReturn(Optional.empty());
 
-    when(accountService.getAccount(anyLong())).thenThrow(new InvalidAccountException());
-
-    var accountController = new AccountController(accountService, accountMapper);
+    var accountService = new AccountService(accountRepository, accountMapper);
+    var accountController = new AccountController(accountService);
 
     assertThrows(InvalidAccountException.class, () -> accountController.getAccountBalance(-1L));
   }
 
   /***
    * Verifies that an invalid account id throws an invalid account exception
-   * @throws InvalidAccountException
    */
   @Test
   void getAccountDetails_validAccount_returnsValidData() {
-    var accountService = mock(AccountService.class);
-    var owner = mock(Owner.class);
-    when(owner.getFirstName()).thenReturn("Ian Robert");
-    when(owner.getLastName()).thenReturn("O'Brien");
+    var accountRepository = mock(AccountRepository.class);
+    given(accountRepository.findById(anyLong())).willReturn(
+        Optional.of(Account.builder()
+            .id(4444L)
+            .balance(0.0)
+            .currency("NOK")
+            .owner(Owner.builder().firstName("Ian Robert").lastName("O'Brien").build())
+            .build()));
 
-    when(accountService.getAccount(anyLong()))
-        .thenReturn(
-            Account.builder().id(4444L).balance(0.0).currency("NOK").owner(owner).build());
-
-    given(accountMapper.toAccountDetails(any(Account.class)))
-        .willReturn(new AccountDetails().accountId(4444L));
-    var accountController = new AccountController(accountService, accountMapper);
-
+    var accountService = new AccountService(accountRepository, accountMapper);
+    var accountController = new AccountController(accountService);
     var accountDetails = accountController.getAccountDetails(4444L);
 
     assertNotNull(accountDetails.getBody());
@@ -101,15 +96,14 @@ class AccountControllerTest {
 
   /***
    * Verifies that an invalid account id throws an invalid account exception
-   * @throws InvalidAccountException
    */
   @Test
-  void getAccountDetails_invalidAccount_throwsException() throws InvalidAccountException {
-    var accountService = mock(AccountService.class);
+  void getAccountDetails_invalidAccount_throwsException() {
+    var accountRepository = mock(AccountRepository.class);
+    var accountService = new AccountService(accountRepository, accountMapper);
 
-    when(accountService.getAccount(anyLong())).thenThrow(new InvalidAccountException());
-
-    var accountController = new AccountController(accountService, accountMapper);
+    given(accountRepository.findById(anyLong())).willReturn(Optional.empty());
+    var accountController = new AccountController(accountService);
 
     assertThrows(InvalidAccountException.class, () -> accountController.getAccountDetails(-1L));
   }

--- a/fakebank-server/src/test/java/no/obrien/fakebank/exception/InsufficientFundsExceptionTest.java
+++ b/fakebank-server/src/test/java/no/obrien/fakebank/exception/InsufficientFundsExceptionTest.java
@@ -3,8 +3,8 @@ package no.obrien.fakebank.exception;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import no.obrien.fakebank.model.Account;
 import no.obrien.fakebank.model.InstructedAmount;
@@ -29,7 +29,7 @@ public class InsufficientFundsExceptionTest {
     var accountService = mock(AccountService.class);
 
     try {
-      when(accountService.getAccount(anyLong())).thenReturn(Account.builder().build());
+      given(accountService.getAccount(anyLong())).willReturn(Account.builder().build());
     } catch (InvalidAccountException e) {
       throw new RuntimeException(e);
     }

--- a/fakebank-server/src/test/java/no/obrien/fakebank/exception/InvalidPaymentRequestExceptionTest.java
+++ b/fakebank-server/src/test/java/no/obrien/fakebank/exception/InvalidPaymentRequestExceptionTest.java
@@ -3,8 +3,8 @@ package no.obrien.fakebank.exception;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import no.obrien.fakebank.model.Account;
 import no.obrien.fakebank.model.InstructedAmount;
@@ -23,15 +23,13 @@ public class InvalidPaymentRequestExceptionTest {
   /***
    * Verifies that requesting a payment with an invalid account throws
    * an invalid account exception
-   * @throws InvalidAccountException
    */
   @Test()
-  void initiatePayment_invalidAccount_throwsInvalidAccountException()
-      throws InvalidAccountException {
+  void initiatePayment_invalidAccount_throwsInvalidAccountException() {
     var accountService = mock(AccountService.class);
     var paymentService = new PaymentService(accountService);
 
-    when(accountService.getAccount(anyLong())).thenReturn(Account.builder().build());
+    given(accountService.getAccount(anyLong())).willReturn(Account.builder().build());
 
     var exception =
         assertThrows(

--- a/fakebank-server/src/test/java/no/obrien/fakebank/interceptor/RequestInterceptorTest.java
+++ b/fakebank-server/src/test/java/no/obrien/fakebank/interceptor/RequestInterceptorTest.java
@@ -1,8 +1,8 @@
 package no.obrien.fakebank.interceptor;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
@@ -22,7 +22,7 @@ public class RequestInterceptorTest {
   @Test
   void validInterceptorResult() {
     var request = mock(HttpServletRequest.class);
-    when(request.getRequestURI()).thenReturn("localhost:8080/accounts/1/balance");
+    given(request.getRequestURI()).willReturn("localhost:8080/accounts/1/balance");
 
     var requestInterceptor = new RequestInterceptor();
     assertTrue(requestInterceptor.preHandle(request, null, null));

--- a/fakebank-server/src/test/java/no/obrien/fakebank/mapper/AccountMapperTest.java
+++ b/fakebank-server/src/test/java/no/obrien/fakebank/mapper/AccountMapperTest.java
@@ -3,8 +3,8 @@ package no.obrien.fakebank.mapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import no.obrien.fakebank.model.Account;
 import no.obrien.fakebank.model.Owner;
@@ -107,7 +107,7 @@ class AccountMapperTest {
     var ownerId = 1L;
 
     var owner = mock(Owner.class);
-    when(owner.getId()).thenReturn(ownerId);
+    given(owner.getId()).willReturn(ownerId);
 
     var account = Account.builder().balance(balance).currency(currency).id(id).owner(owner).build();
 

--- a/fakebank-server/src/test/java/no/obrien/fakebank/repository/AccountRepositoryMockTest.java
+++ b/fakebank-server/src/test/java/no/obrien/fakebank/repository/AccountRepositoryMockTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /***

--- a/fakebank-server/src/test/java/no/obrien/fakebank/service/AccountServiceMockTest.java
+++ b/fakebank-server/src/test/java/no/obrien/fakebank/service/AccountServiceMockTest.java
@@ -1,45 +1,48 @@
 package no.obrien.fakebank.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.Optional;
-import no.obrien.fakebank.exception.InvalidAccountException;
+import no.obrien.fakebank.mapper.AccountMapper;
 import no.obrien.fakebank.model.Account;
 import no.obrien.fakebank.model.Owner;
 import no.obrien.fakebank.repository.AccountRepository;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
 
 /***
  * Tests the account provider
  */
+@ContextConfiguration(classes = {AccountMapper.class})
 public class AccountServiceMockTest {
+
+  @MockBean
+  private AccountMapper accountMapper;
 
   /***
    * Verifies that a valid account request returns the valid account
-   * @throws InvalidAccountException
    */
   @Test
-  void getAccount_validInput_validOutput() throws InvalidAccountException {
+  void getAccount_validInput_validOutput() {
     var id = 1L;
     var balance = 0.0;
     var currency = "NOK";
 
-    var owner = mock(Owner.class);
-    when(owner.getFirstName()).thenReturn("Ian Robert");
-    when(owner.getLastName()).thenReturn("O'Brien");
+    var owner = Owner.builder().firstName("Ian Robert").lastName("O'Brien").build();
 
     var accountRepository = mock(AccountRepository.class);
-    when(accountRepository.findById(id))
-        .thenReturn(
+    given(accountRepository.findById(id))
+        .willReturn(
             Optional.of(Account.builder()
                 .id(id)
                 .balance(balance)
                 .currency(currency)
                 .owner(owner).build()));
 
-    var accountService = new AccountService(accountRepository);
+    var accountService = new AccountService(accountRepository, accountMapper);
 
     var account = accountService.getAccount(id);
     assertEquals(id, account.getId());

--- a/fakebank-server/src/test/java/no/obrien/fakebank/service/AccountServiceTest.java
+++ b/fakebank-server/src/test/java/no/obrien/fakebank/service/AccountServiceTest.java
@@ -3,18 +3,25 @@ package no.obrien.fakebank.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import no.obrien.fakebank.mapper.AccountMapper;
 import no.obrien.fakebank.model.Account;
 import no.obrien.fakebank.repository.AccountRepositoryMock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {AccountMapper.class})
 class AccountServiceTest {
+
+  @MockBean
+  private AccountMapper accountMapper;
 
   @Test
   void getAccount() {
-    var accountService = new AccountService(new AccountRepositoryMock());
+    var accountService = new AccountService(new AccountRepositoryMock(), accountMapper);
     assertEquals(
         "Ian Robert",
         accountService.getAccount(1L).getOwner().getFirstName());
@@ -22,7 +29,7 @@ class AccountServiceTest {
 
   @Test
   void saveAccount() {
-    var accountService = new AccountService(new AccountRepositoryMock());
+    var accountService = new AccountService(new AccountRepositoryMock(), accountMapper);
     assertThrows(UnsupportedOperationException.class,
         () -> accountService.saveAccount(new Account()));
   }


### PR DESCRIPTION
This pull request refactors the `AccountController` and associated tests to streamline the code and improve maintainability. The key changes include removing the `AccountMapper` from the `AccountController`, moving the mapping logic to the `AccountService`, and updating the tests to reflect these changes.

### Refactoring of `AccountController`:

* Removed `AccountMapper` dependency from `AccountController` and adjusted methods to use `AccountService` directly for obtaining account details and balance. (`fakebank-server/src/main/java/no/obrien/fakebank/controller/AccountController.java`) [[1]](diffhunk://#diff-75f2fe291996b4ca99d3e9c3df057ce5b6affc50cce0f87f88f079e329615854L7-L8) [[2]](diffhunk://#diff-75f2fe291996b4ca99d3e9c3df057ce5b6affc50cce0f87f88f079e329615854L25) [[3]](diffhunk://#diff-75f2fe291996b4ca99d3e9c3df057ce5b6affc50cce0f87f88f079e329615854L36-R33) [[4]](diffhunk://#diff-75f2fe291996b4ca99d3e9c3df057ce5b6affc50cce0f87f88f079e329615854L49-R45)

### Changes in `AccountService`:

* Added methods `getAccountDetails` and `getAccountBalance` to `AccountService` to encapsulate the mapping logic previously in `AccountController`. (`fakebank-server/src/main/java/no/obrien/fakebank/service/AccountService.java`) [[1]](diffhunk://#diff-05677013b4960206db349343d1bfb854d4550b00583d17ad7e1b748135f3bed0R7-R10) [[2]](diffhunk://#diff-05677013b4960206db349343d1bfb854d4550b00583d17ad7e1b748135f3bed0R23) [[3]](diffhunk://#diff-05677013b4960206db349343d1bfb854d4550b00583d17ad7e1b748135f3bed0R38-R57)

### Updates to Tests:

* Updated `AccountControllerTest` to reflect the removal of `AccountMapper` from `AccountController` and added necessary mocks and context configuration. (`fakebank-server/src/test/java/no/obrien/fakebank/controller/AccountControllerTest.java`) [[1]](diffhunk://#diff-dce6d36d996298dc765d2cbb347f5839c365fdb285880c2509fbd1a7d3ea9515L6-R20) [[2]](diffhunk://#diff-dce6d36d996298dc765d2cbb347f5839c365fdb285880c2509fbd1a7d3ea9515L30-R51) [[3]](diffhunk://#diff-dce6d36d996298dc765d2cbb347f5839c365fdb285880c2509fbd1a7d3ea9515L63-R89) [[4]](diffhunk://#diff-dce6d36d996298dc765d2cbb347f5839c365fdb285880c2509fbd1a7d3ea9515L104-R106)
* Adjusted `PaymentControllerTest` to use `BDDMockito` for mocking and added `AccountMapper` as a mock bean. (`fakebank-server/src/test/java/no/obrien/fakebank/controller/PaymentControllerTest.java`) [[1]](diffhunk://#diff-e8c8593974509bdac4e9fb9c26ae64d76c35c79d004f9d412ee7ea52d5e2968fR7-R14) [[2]](diffhunk://#diff-e8c8593974509bdac4e9fb9c26ae64d76c35c79d004f9d412ee7ea52d5e2968fR24-R48) [[3]](diffhunk://#diff-e8c8593974509bdac4e9fb9c26ae64d76c35c79d004f9d412ee7ea52d5e2968fL58-R70) [[4]](diffhunk://#diff-e8c8593974509bdac4e9fb9c26ae64d76c35c79d004f9d412ee7ea52d5e2968fL80-R93) [[5]](diffhunk://#diff-e8c8593974509bdac4e9fb9c26ae64d76c35c79d004f9d412ee7ea52d5e2968fL112-R120)
* Updated exception tests to use `BDDMockito` for consistent mocking style. (`fakebank-server/src/test/java/no/obrien/fakebank/exception/InsufficientFundsExceptionTest.java`, `fakebank-server/src/test/java/no/obrien/fakebank/exception/InvalidPaymentRequestExceptionTest.java`) [[1]](diffhunk://#diff-350fd32819804e3500315c03ad1671cd4ff35bd7c2ef18b580aa4d36b8e7cee5R6-L7) [[2]](diffhunk://#diff-350fd32819804e3500315c03ad1671cd4ff35bd7c2ef18b580aa4d36b8e7cee5L32-R32) [[3]](diffhunk://#diff-05a239114a2f75f63bf08a24e6ffd77eebaf124ed5b2c2b691f657430bbaae08R6-L7) [[4]](diffhunk://#diff-05a239114a2f75f63bf08a24e6ffd77eebaf124ed5b2c2b691f657430bbaae08L26-R32)
* Modified `RequestInterceptorTest` to use `BDDMockito` for mocking. (`fakebank-server/src/test/java/no/obrien/fakebank/interceptor/RequestInterceptorTest.java`) [[1]](diffhunk://#diff-d786d85fb137b7448a49e697bf001c73ffd794142d2d3b167fcf168bb8b100cbR4-L5) [[2]](diffhunk://#diff-d786d85fb137b7448a49e697bf001c73ffd794142d2d3b167fcf168bb8b100cbL25-R25)