### PR TITLE
Enable vale

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,36 +13,36 @@ env:
   IMAGE_NAME: fakebank
 
 jobs:
-#  changes:
-#    name: "Checking folders for changes"
-#    runs-on: ubuntu-latest
-#    outputs:
-#      app: ${{ steps.changes.outputs.app }}
-#    steps:
-#      - name: "Checkout"
-#        uses: actions/checkout@v4
-#      - uses: dorny/paths-filter@v3.0.2
-#        id: changes
-#        with:
-#          filters: |
-#            app:
-#              - 'fakebank-impl/**'
-#              - 'fakebake-api/**'
-#  vale:
-#    name: Vale
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: errata-ai/vale-action@reviewdog
-#        with:
-#          fail_on_error: true
-#          reporter: github-check
-#          vale_flags: "--glob=*.{md,txt}"
-#        env:
-#          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  #  changes:
+  #    name: "Checking folders for changes"
+  #    runs-on: ubuntu-latest
+  #    outputs:
+  #      app: ${{ steps.changes.outputs.app }}
+  #    steps:
+  #      - name: "Checkout"
+  #        uses: actions/checkout@v4
+  #      - uses: dorny/paths-filter@v3.0.2
+  #        id: changes
+  #        with:
+  #          filters: |
+  #            app:
+  #              - 'fakebank-impl/**'
+  #              - 'fakebake-api/**'
+  vale:
+    name: Vale
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: errata-ai/vale-action@reviewdog
+        with:
+          fail_on_error: true
+          reporter: github-check
+          vale_flags: "--glob=*.{md,txt}"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   build:
-#    needs: [vale]
-#    if: ${{ needs.changes.outputs.app == 'true' }}
+    needs: [vale]
+    #    if: ${{ needs.changes.outputs.app == 'true' }}
     name: Build
     runs-on: ubuntu-latest
     permissions:
@@ -97,7 +97,7 @@ jobs:
           path: 'www/coverage/'
   build-store-image:
     needs: [build]
-#    if: ${{ needs.changes.outputs.app == 'true' }}
+    #    if: ${{ needs.changes.outputs.app == 'true' }}
     name: Build and store image
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,20 +23,20 @@ jobs:
   #            app:
   #              - 'fakebank-impl/**'
   #              - 'fakebake-api/**'
-  #  vale:
-  #    name: Vale
-  #    runs-on: ubuntu-latest
-  #    steps:
-  #      - uses: actions/checkout@v4
-  #      - uses: errata-ai/vale-action@reviewdog
-  #        with:
-  #          fail_on_error: true
-  #          reporter: github-check
-  #          vale_flags: "--glob=*.{md,txt}"
-  #        env:
-  #          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  vale:
+    name: Vale
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: errata-ai/vale-action@reviewdog
+        with:
+          fail_on_error: true
+          reporter: github-check
+          vale_flags: "--glob=*.{md,txt}"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   build:
-    #    needs: [vale]
+    needs: [vale]
     #    if: ${{ needs.changes.outputs.app == 'true' }}
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request re-enables the Vale linter in the CI and PR workflows to ensure consistent documentation standards. The most important changes include uncommenting and updating the Vale job configurations in both `.github/workflows/ci.yaml` and `.github/workflows/pr.yaml`.

Re-enabling Vale linter:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL31-R44): Uncommented and updated the Vale job configuration to ensure it runs on `ubuntu-latest` and uses the `errata-ai/vale-action@reviewdog` action.
* [`.github/workflows/pr.yaml`](diffhunk://#diff-1eb4e5fd5611777d4e597ef299a1cb5ba8050c28a2dabbd4fbc56205d69e5ddaL26-R39): Similarly uncommented and updated the Vale job configuration to ensure it runs on `ubuntu-latest` and uses the `errata-ai/vale-action@reviewdog` action.